### PR TITLE
Allow for a single .eslintrc.js that detects Jessie

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {},
   "files": [
-    "index.js"
+    "index.js",
+    "util.js"
   ]
 }

--- a/sample.eslintrc.js
+++ b/sample.eslintrc.js
@@ -1,0 +1,36 @@
+/* global module */
+const overrides = [];
+
+// Guard against infinite recursion.
+if (!process.env.DISABLE_JESSIE_OVERRIDE) {
+  const { partitionFromGlobs } = require('eslint-config-jessie/jessie-eslint');
+  const [jessieFiles] = partitionFromGlobs(['**/*.js'], __dirname);
+  if (jessieFiles.length) {
+    // We have some Jessie files to apply against.
+    overrides.push({
+      files: jessieFiles,
+      extends: ["jessie"],
+    });
+  }
+}
+
+module.exports = {
+  env: {
+    es6: true, // supports new ES6 globals (e.g., new types such as Set)
+  },
+  overrides,
+  rules: {
+    'implicit-arrow-linebreak': 'off',
+    'function-paren-newline': 'off',
+    'arrow-parens': 'off',
+    strict: 'off',
+    'no-console': 'off',
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-return-assign': 'off',
+    'no-param-reassign': 'off',
+    'no-restricted-syntax': ['off', 'ForOfStatement'],
+    'no-unused-expressions': 'off',
+    'no-loop-func': 'off',
+    'import/prefer-default-export': 'off', // contrary to Agoric standard
+  },
+};

--- a/sample.eslintrc.js
+++ b/sample.eslintrc.js
@@ -1,15 +1,16 @@
-/* global module */
+// eslint-disable-next-line import/no-unresolved
+const { partitionFromGlobs } = require('eslint-config-jessie/util');
+
 const overrides = [];
 
 // Guard against infinite recursion.
 if (!process.env.DISABLE_JESSIE_OVERRIDE) {
-  const { partitionFromGlobs } = require('eslint-config-jessie/jessie-eslint');
   const [jessieFiles] = partitionFromGlobs(['**/*.js'], __dirname);
   if (jessieFiles.length) {
     // We have some Jessie files to apply against.
     overrides.push({
       files: jessieFiles,
-      extends: ["jessie"],
+      extends: ['jessie'],
     });
   }
 }

--- a/util.js
+++ b/util.js
@@ -1,8 +1,10 @@
 const fs = require('fs');
 const { FileEnumerator } = require('eslint/lib/cli-engine/file-enumerator');
-const { CascadingConfigArrayFactory } = require('eslint/lib/cli-engine/cascading-config-array-factory');
+const {
+  CascadingConfigArrayFactory,
+} = require('eslint/lib/cli-engine/cascading-config-array-factory');
 
-exports.indexOfFirstStatement = function indexOfFirstStatement(text) {
+function indexOfFirstStatement(text) {
   let i = 0;
   let slashStarComment = false;
 
@@ -40,20 +42,22 @@ exports.indexOfFirstStatement = function indexOfFirstStatement(text) {
   }
   return -1;
 }
+exports.indexOfFirstStatement = indexOfFirstStatement;
 
-exports.partitionFiles = function partitionFiles(files, dir = '') {
+function partitionFiles(files, dir = '') {
   const jessieFiles = [];
   const nonJessieFiles = [];
   for (const f of files) {
     if (!f.endsWith('.js')) {
       nonJessieFiles.push(f);
+      // eslint-disable-next-line no-continue
       continue;
     }
 
     // maybe a Jessie file
     let isJessie = false;
     // TODO: Maybe lazily read the file.
-    const rawText = fs.readFileSync(`${dir}${f}`, 'utf-8', );
+    const rawText = fs.readFileSync(`${dir}${f}`, 'utf-8');
     const text = rawText.startsWith('#!') ? `// ${rawText}` : rawText;
 
     // Find the 'use jessie' token.
@@ -74,9 +78,10 @@ exports.partitionFiles = function partitionFiles(files, dir = '') {
     }
   }
   return [jessieFiles, nonJessieFiles];
-};
+}
 
-exports.partitionFromGlobs = function partitionFromGlobs(globs, cwd = undefined) {
+exports.partitionFiles = partitionFiles;
+function partitionFromGlobs(globs, cwd = undefined) {
   const ccaf = new CascadingConfigArrayFactory({ cwd });
   const configArrayFactory = {
     getConfigArrayForFile(filePath) {
@@ -88,7 +93,7 @@ exports.partitionFromGlobs = function partitionFromGlobs(globs, cwd = undefined)
       }
     },
   };
-  const enumerator = new FileEnumerator({configArrayFactory, cwd});
+  const enumerator = new FileEnumerator({ configArrayFactory, cwd });
   const files = [];
   const dir = cwd ? `${cwd}/` : '';
   for (const { filePath } of enumerator.iterateFiles(globs)) {
@@ -102,3 +107,5 @@ exports.partitionFromGlobs = function partitionFromGlobs(globs, cwd = undefined)
   const [jessieFiles, nonJessieFiles] = partitionFiles(files, dir);
   return [jessieFiles, nonJessieFiles];
 }
+
+exports.partitionFromGlobs = partitionFromGlobs;

--- a/util.js
+++ b/util.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const { FileEnumerator } = require('eslint/lib/cli-engine/file-enumerator');
+const { CascadingConfigArrayFactory } = require('eslint/lib/cli-engine/cascading-config-array-factory');
+
+exports.indexOfFirstStatement = function indexOfFirstStatement(text) {
+  let i = 0;
+  let slashStarComment = false;
+
+  while (i < text.length) {
+    let s = text.substr(i);
+    if (slashStarComment) {
+      const endComment = s.match(/^.*?\*\//s);
+      if (endComment) {
+        slashStarComment = false;
+        i += endComment[0].length;
+      } else {
+        return -1;
+      }
+    } else {
+      const ws = s.match(/^\s+/);
+      if (ws) {
+        i += ws[0].length;
+        s = text.substr(i);
+      }
+
+      const multilineComment = s.match(/^\/\*/);
+      if (multilineComment) {
+        slashStarComment = true;
+        i += multilineComment[0].length;
+      } else {
+        const lineComment = s.match(/^\/\/.*/);
+        if (lineComment) {
+          i += lineComment[0].length;
+        } else {
+          // No comments, no whitespace.
+          return i;
+        }
+      }
+    }
+  }
+  return -1;
+}
+
+exports.partitionFiles = function partitionFiles(files, dir = '') {
+  const jessieFiles = [];
+  const nonJessieFiles = [];
+  for (const f of files) {
+    if (!f.endsWith('.js')) {
+      nonJessieFiles.push(f);
+      continue;
+    }
+
+    // maybe a Jessie file
+    let isJessie = false;
+    // TODO: Maybe lazily read the file.
+    const rawText = fs.readFileSync(`${dir}${f}`, 'utf-8', );
+    const text = rawText.startsWith('#!') ? `// ${rawText}` : rawText;
+
+    // Find the 'use jessie' token.
+    const pos = indexOfFirstStatement(text);
+    if (pos >= 0) {
+      for (const jessieToken of ['"use jessie";', "'use jessie';"]) {
+        if (text.substr(pos, jessieToken.length) === jessieToken) {
+          isJessie = true;
+          break;
+        }
+      }
+    }
+
+    if (isJessie) {
+      jessieFiles.push(f);
+    } else {
+      nonJessieFiles.push(f);
+    }
+  }
+  return [jessieFiles, nonJessieFiles];
+};
+
+exports.partitionFromGlobs = function partitionFromGlobs(globs, cwd = undefined) {
+  const ccaf = new CascadingConfigArrayFactory({ cwd });
+  const configArrayFactory = {
+    getConfigArrayForFile(filePath) {
+      try {
+        process.env.DISABLE_JESSIE_OVERRIDE = 'true';
+        return ccaf.getConfigArrayForFile(filePath);
+      } finally {
+        delete process.env.DISABLE_JESSIE_OVERRIDE;
+      }
+    },
+  };
+  const enumerator = new FileEnumerator({configArrayFactory, cwd});
+  const files = [];
+  const dir = cwd ? `${cwd}/` : '';
+  for (const { filePath } of enumerator.iterateFiles(globs)) {
+    if (filePath.startsWith(dir)) {
+      files.push(filePath.substr(dir.length));
+    } else {
+      files.push(filePath);
+    }
+  }
+  // console.log('have files', files);
+  const [jessieFiles, nonJessieFiles] = partitionFiles(files, dir);
+  return [jessieFiles, nonJessieFiles];
+}


### PR DESCRIPTION
This works by reading the source files for an initial
`'use jessie';` or `"use jessie";` token (skipping whitespace and
comments).

The `sample.eslintrc.js` shows how to use it.
